### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/scripts/names_role.py
+++ b/scripts/names_role.py
@@ -36,7 +36,7 @@ def extract_name(names, subregex=None):
                 before = a
                 a = re.sub(r'\b' + s[0], s[1], a)
                 if a != before:
-                    print("'%s' ==> '%s': '%s' ==> '%s'" % (s[0], s[1],
+                    print("'{0!s}' ==> '{1!s}': '{2!s}' ==> '{3!s}'".format(s[0], s[1],
                                                             before, a))
         a = re.split(r'[,&/•]', a)
         for b in a:
@@ -46,7 +46,7 @@ def extract_name(names, subregex=None):
             else:
                 # print out one-word name
                 if len(c):
-                    print("%s ==> '%s'" % (names, c))
+                    print("{0!s} ==> '{1!s}'".format(names, c))
     return r
 
 

--- a/scripts/tv_schedules.py
+++ b/scripts/tv_schedules.py
@@ -44,7 +44,7 @@ def table_to_2d_dict(table):
             # Issue #3: Add link magic
             links = col.findall('.//a')
             if len(links):
-                col_data += "<<%s>>" % links[0].get('href')
+                col_data += "<<{0!s}>>".format(links[0].get('href'))
             while row_i in result and col_i in result[row_i]:
                 col_i += 1
             for i in range(row_i, row_i + rowspan):
@@ -68,7 +68,7 @@ def _unpack(row, kind='td'):
         elts = row.findall('.//th')
     else:
         elts = []
-    elts += row.findall('.//%s' % kind)
+    elts += row.findall('.//{0!s}'.format(kind))
     cols = []
     for e in elts:
         try:

--- a/scripts/tv_schedules_meta.py
+++ b/scripts/tv_schedules_meta.py
@@ -45,7 +45,7 @@ def table_to_2d_dict(table, with_link=True):
             if with_link:
                 links = col.findall('.//a')
                 if len(links):
-                    col_data += "<<%s>>" % links[0].get('href')
+                    col_data += "<<{0!s}>>".format(links[0].get('href'))
             while row_i in result and col_i in result[row_i]:
                 col_i += 1
             for i in range(row_i, row_i + rowspan):
@@ -69,7 +69,7 @@ def _unpack(row, kind='td'):
         elts = row.findall('.//th')
     else:
         elts = []
-    elts += row.findall('.//%s' % kind)
+    elts += row.findall('.//{0!s}'.format(kind))
     cols = []
     for e in elts:
         try:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:tv_schedules?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:soodoku:tv_schedules?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)